### PR TITLE
Update Mapbox satellite url

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -13,7 +13,7 @@
   </set>
   <set>
     <name>MapBox Satellite</name>
-    <url>http://${a|b|c}.tiles.mapbox.com/v3/openstreetmap.map-4wvf9l0l/$z/$x/$y.png</url>
+    <url>http://${a|b|c}.tiles.mapbox.com/v4/openstreetmap.map-inh7ifmo/$z/$x/$y.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q</url>
     <terms_url>http://mapbox.com/tos/</terms_url>
     <sourcetag>MapBox Satellite</sourcetag>
   </set>


### PR DESCRIPTION
I switched this url out on iD and JOSM a few weeks ago, then killed that map. We were notified it stopped working in Potlatch as well. Here's a fix.
